### PR TITLE
Add a parameter to the `off` function, to allow fine-tuned removal of callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ CustomEvent.dispatch('SHOW_NAME', { name: 'GitHub' })
 
 // Remove event listener
 CustomEvent.off('SHOW_NAME')
+
+or
+
+CustomEvent.off('SHOW_NAME', callback)
 ```
 
 ## API
@@ -34,7 +38,9 @@ CustomEvent.off('SHOW_NAME')
 
 - **dispatch(eventName, detail)** dispatch event to all event listeners
 
-- **off(eventName)** remove event listener
+- **off(eventName)** remove all event listeners for the event
+
+- **off(eventName, callback)** remove a specific event listener for the event
 
 
 ## Contributing

--- a/src/custom-event.js
+++ b/src/custom-event.js
@@ -54,16 +54,23 @@ module.exports = {
 	/**
 	 * @param {String} eventName
 	 */
-	off: function (eventName) {
+	off: function (eventName, callbackToRemove) {
 		if (!EVENTS[eventName]) {
 			return;
 		}
 
-		EVENTS[eventName].callbacks.forEach(callback => {
+		EVENTS[eventName].callbacks.filter(callback => !callbackToRemove || callback === callbackToRemove).forEach(callback => {
 			TARGET.removeEventListener(eventName, callback);
 		});
+		if (callbackToRemove) {
+			EVENTS[eventName].callbacks = EVENTS[eventName].callbacks.filter(callback => callback !== callbackToRemove);
+			if (EVENTS[eventName].callbacks.length === 0) {
+				delete EVENTS[eventName];
+			}
+		} else {
+			delete EVENTS[eventName];
+		}
 
-		delete EVENTS[eventName];
 	},
 
 	/**


### PR DESCRIPTION
Add the ability to remove a specific callback instead of all callbacks, for cases where you might not own all the custom event callbacks for a particular event.