### PR TITLE
initCustomEvent is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ CustomEvent.dispatch('SHOW_NAME', { name: 'GitHub' })
 
 // Remove event listener
 CustomEvent.off('SHOW_NAME')
+
+or
+
+CustomEvent.off('SHOW_NAME', callback)
 ```
 
 ## API
@@ -34,7 +38,9 @@ CustomEvent.off('SHOW_NAME')
 
 - **dispatch(eventName, detail)** dispatch event to all event listeners
 
-- **off(eventName)** remove event listener
+- **off(eventName)** remove all event listeners for the event
+
+- **off(eventName, callback)** remove a specific event listener for the event
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![MIT Licence](https://badges.frapsoft.com/os/mit/mit.svg?v=103)](https://opensource.org/licenses/mit-license.php) [![npm version](https://badge.fury.io/js/custom-event-js.svg)](https://badge.fury.io/js/custom-event-js)
 [![Known Vulnerabilities](https://snyk.io/test/github/shystruk/custom-event-js/badge.svg?targetFile=package.json)](https://snyk.io/test/github/shystruk/custom-event-js?targetFile=package.json)
 
-The Custom Event Dispatcher provides the ability to communicate inside your application by dispatching events and listening to them. It also runs polyfill for Internet Explorer 9 and higher. What is the CustomEvent interface you may find [here](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent). 
+The Custom Event Dispatcher provides the ability to communicate inside your application by dispatching events and listening to them. What is the CustomEvent interface you may find [here](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent).
 
-> **Custom Event Dispatcher works in all popular browsers, including Internet Explorer 9 and higher.**
+> **Custom Event Dispatcher works in all popular browsers**
 
 ## Install ##
 #### npm
@@ -28,8 +28,7 @@ CustomEvent.dispatch('SHOW_NAME', { name: 'GitHub' })
 // Remove event listener
 CustomEvent.off('SHOW_NAME')
 
-or
-
+// Remove a specific callback from event listener
 CustomEvent.off('SHOW_NAME', callback)
 ```
 

--- a/src/custom-event.js
+++ b/src/custom-event.js
@@ -54,16 +54,23 @@ module.exports = {
 	/**
 	 * @param {String} eventName
 	 */
-	off: function (eventName) {
+	off: function (eventName, callbackToRemove) {
 		if (!EVENTS[eventName]) {
 			return;
 		}
 
-		EVENTS[eventName].callbacks.forEach(callback => {
+		EVENTS[eventName].callbacks.filter(callback => !callbackToRemove || callback === callbackToRemove).forEach(callback => {
 			TARGET.removeEventListener(eventName, callback);
 		});
+		if (callbackToRemove) {
+			EVENTS[eventName].callbacks = EVENTS[eventName].callbacks.filter(callback => callback !== callbackToRemove);
+			if (EVENTS[eventName].callbacks.length === 0) {
+				delete EVENTS[eventName];
+			}
+		} else {
+			delete EVENTS[eventName];
+		}
 
-		delete EVENTS[eventName];
 	},
 
 	/**


### PR DESCRIPTION
- remove IE9 polyfill (initCustomEvent is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent)) 
-  add the ability to remove a specific event listener for an event